### PR TITLE
Rename CopyDLL to DeployDLL

### DIFF
--- a/ArasSync/ArasSync.csproj
+++ b/ArasSync/ArasSync.csproj
@@ -80,7 +80,7 @@
     <Compile Include="Commands\RunAmlCommand.cs" />
     <Compile Include="Commands\UploadDocCommand.cs" />
     <Compile Include="Commands\ForAllCommand.cs" />
-    <Compile Include="Commands\CopyDllCommand.cs" />
+    <Compile Include="Commands\DeployDllCommand.cs" />
     <Compile Include="Commands\ImportFilesCommand.cs" />
     <Compile Include="Ops\Config.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/ArasSync/Commands/DeployCommand.cs
+++ b/ArasSync/Commands/DeployCommand.cs
@@ -50,7 +50,7 @@ namespace BitAddict.Aras.ArasSync.Commands
                 AmlSyncFile = AmlSyncFile,
                 Confirm = false,
             }.Run(new string[] { });
-            new CopyDllCommand
+            new DeployDllCommand
             {
                 Database = Database,
                 Confirm = false,

--- a/ArasSync/Commands/DeployDllCommand.cs
+++ b/ArasSync/Commands/DeployDllCommand.cs
@@ -13,7 +13,7 @@ namespace BitAddict.Aras.ArasSync.Commands
     /// Build and copies DLLs
     /// </summary>
     [UsedImplicitly]
-    public class CopyDllCommand : ConsoleCommand
+    public class DeployDllCommand : ConsoleCommand
     {
         public bool Confirm { get; set; } = true;
         public bool Build { get; set; } = true;
@@ -22,9 +22,9 @@ namespace BitAddict.Aras.ArasSync.Commands
         public string BuildConfig { get; set; } = "Release";
         public bool Doc { get; set; } = true;
 
-        public CopyDllCommand()
+        public DeployDllCommand()
         {
-            IsCommand("CopyDLL", "Builds and copies DLLs & docs for the current feature to the Aras Web Server bin folder");
+            IsCommand("DeployDLL", "Builds and copies DLLs & docs for the current feature to the Aras Web Server bin folder");
 
             HasOption("dir=|directory=", "Directory to copy to", dir => Dir = dir);
             HasOption("db=|database=", "Database Id to copy to", db => Database = db);
@@ -89,7 +89,7 @@ namespace BitAddict.Aras.ArasSync.Commands
             if (targetFolder == null)
                 throw new ArgumentNullException(nameof(targetFolder), "internal error");
 
-            var info = Config.GetCopyDllInfo();
+            var info = Config.GetDeployDllInfo();
 
             Console.WriteLine($"About to copy [{string.Join(",", info.Extensions.Distinct().Select(e => $"*{e}"))}]\n" +
                               $"  from: {sourceFolder}\n" +

--- a/ArasSync/Ops/Config.cs
+++ b/ArasSync/Ops/Config.cs
@@ -55,7 +55,7 @@ namespace BitAddict.Aras.ArasSync.Ops
             return arasDb;
         }
 
-        internal static CopyDllInfo GetCopyDllInfo()
+        internal static DeployDllInfo GetDeployDllInfo()
         {
             var arasConf = (new[] {"arasdb-local.json", "arasdb.json"}
                 .Select(mfFile => Path.Combine(SolutionDir.FullName, mfFile))
@@ -67,10 +67,10 @@ namespace BitAddict.Aras.ArasSync.Ops
             if (arasConf == null)
                 throw new UserMessageException($"No arasdb(-local).json found at {SolutionDir.FullName}.");
 
-            if (arasConf.CopyDll == null)
-                throw new UserMessageException("No CopyDll section found in arasdb(-local).json.");
+            if (arasConf.DeployDll == null)
+                throw new UserMessageException("No DeployDll section found in arasdb(-local).json.");
 
-            return arasConf.CopyDll;
+            return arasConf.DeployDll;
         }
     }
 }

--- a/BitAddict.Aras/Data/ArasConfManifest.cs
+++ b/BitAddict.Aras/Data/ArasConfManifest.cs
@@ -25,7 +25,7 @@ namespace BitAddict.Aras.Data
         /// <summary>
         /// File copying information
         /// </summary>
-        public CopyDllInfo CopyDll { get; set; }
+        public DeployDllInfo DeployDll { get; set; }
     }
 
     /// <summary>
@@ -43,21 +43,21 @@ namespace BitAddict.Aras.Data
         /// </summary>
         public string Url { get; set; }
         /// <summary>
-        /// Database name as in web login dialgo
+        /// Database name as in web login dialog
         /// </summary>
         public string DbName { get; set; }
         /// <summary>
-        /// Web server 'binaries', i.e. c:\program files (x86)\Aras\TheInstance\
+        /// Web server 'binaries', i.e. C:\Program Files (x86)\Aras\TheInstance\
         /// </summary>
         public string BinFolder { get; set; }
     }
 
     /// <summary>
-    /// Configures copyDLL command with extensions and exclusions
+    /// Configures DeployDLL command with extensions and exclusions
     /// </summary>    
     [UsedImplicitly]
     [SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
-    public class CopyDllInfo
+    public class DeployDllInfo
     {
         /// <summary>
         /// Copies these extensions only

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Advanced available commands are:
 Standard available commands are:
 
     About       - Shows full license/copyright notice
-    CopyDLL     - Builds and copies DLLs & docs for the current feature to the Aras Web Server bin folder
+    DeployDLL   - Builds and copies DLLs & docs for the current feature to the Aras Web Server bin folder
     Deploy      - Deploy the current directory's feature into the Aras instance
     Export      - Exports the current directory's feature from Aras database to disk
     ImportAML   - Imports the current directory's AML from local disc into an Aras database

--- a/arasdb.json
+++ b/arasdb.json
@@ -8,7 +8,7 @@
       "binFolder": "C:\\Program Files (x86)\\Aras\\Innovator"
     }
   ],
-  "CopyDll": {
+  "DeployDll": {
     "Extensions": [ ".dll", ".pdb" ],
     "Excludes": [
       "Aras.Diagnostics",


### PR DESCRIPTION
This slightly better reflects what it does since it also builds and generates documentation etc. Could give slight backwards incompatibility issues since the json-config key is also changed, I'm not sure how much we use that but it should be trivial to change.